### PR TITLE
ci: Use explicit SHA in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - uses: ${{ github.repository }}@${{ github.sha }}
   with-config:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - uses: ${{ github.repository }}@${{ github.sha }}
         with:
           config: config.pdf.yml


### PR DESCRIPTION
Replace `uses: ./` with `uses: ${{ github.repository }}@${{ github.sha }}`
to make the workflow more robust and avoid path resolution issues
when testing the action within its own repository. This is a
best practice for workflow reproducibility and security.
